### PR TITLE
add square brakets around anonymized tokens

### DIFF
--- a/app/processor.py
+++ b/app/processor.py
@@ -160,7 +160,7 @@ def encode_pii_in_text(pii_entities: list, text: str, salt: str) -> tuple[str, d
         start = ent[ResponseKeys.START_IDX.value] - offset
         stop = ent[ResponseKeys.END_IDX.value] - offset
         # substitute into text subtracting offset
-        text = text[:start] + md5_hash + text[stop:]
+        text = text[:start] + "[" + md5_hash  + "]" + text[stop:]
         # update offset to account for the new string
         offset = original_text_length - len(text)
 

--- a/app/processor.py
+++ b/app/processor.py
@@ -160,7 +160,7 @@ def encode_pii_in_text(pii_entities: list, text: str, salt: str) -> tuple[str, d
         start = ent[ResponseKeys.START_IDX.value] - offset
         stop = ent[ResponseKeys.END_IDX.value] - offset
         # substitute into text subtracting offset
-        text = text[:start] + "[" + md5_hash  + "]" + text[stop:]
+        text = text[:start] + "[" + md5_hash + "]" + text[stop:]
         # update offset to account for the new string
         offset = original_text_length - len(text)
 

--- a/app/test_processor.py
+++ b/app/test_processor.py
@@ -83,7 +83,7 @@ def test_encode_pii_for_output():
     }
     salt = "hello what about this"
     out = encode_pii_for_output(data, salt)
-    correct_text = "563ab3ceed81014fe6c2e8b41dac1f4f lives in 6f1a3150659516bb13192915c3a8df66"
+    text = "[563ab3ceed81014fe6c2e8b41dac1f4f] lives in [6f1a3150659516bb13192915c3a8df66]"
     assert (
-        out["text"] == correct_text
+        out["text"] == text
     ), "text anonymized incorrectly"


### PR DESCRIPTION
update reversible anonymization endpoint to put square brackets around anonymized tokens