### PR TITLE
Update Docker hub datafog description with README.md

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -49,12 +49,12 @@ jobs:
         run: |
           # Get the current README.md content
           README_CONTENT=$(cat README.md)
-  
+
           # Define the Docker Hub API URL
           API_URL="https://hub.docker.com/v2/repositories/datafog/datafog-api/"
-  
+
           # Create JSON payload
           JSON_PAYLOAD=$(jq -n --arg msg "$README_CONTENT" '{"full_description": $msg}')
-  
+
           # Send a PATCH request to update the description
           curl -s -X PATCH -H "Content-Type: application/json" -H "Authorization: JWT $(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"$DOCKER_USERNAME\", \"password\": \"$DOCKER_ACCESS_TOKEN\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)" -d "$JSON_PAYLOAD" $API_URL

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -2,8 +2,6 @@
 name: Main Docker
 
 on:
-  pull_request:
-    branches: ["dev"]
   workflow_run:
     workflows: ["Main and Dev CICD datafog-api app"]
     branches:

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -2,6 +2,8 @@
 name: Main Docker
 
 on:
+  pull_request:
+    branches: ["dev"]
   workflow_run:
     workflows: ["Main and Dev CICD datafog-api app"]
     branches:
@@ -40,3 +42,19 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Update Docker Hub README
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          # Get the current README.md content
+          README_CONTENT=$(cat README.md)
+  
+          # Define the Docker Hub API URL
+          API_URL="https://hub.docker.com/v2/repositories/datafog/datafog-api/"
+  
+          # Create JSON payload
+          JSON_PAYLOAD=$(jq -n --arg msg "$README_CONTENT" '{"full_description": $msg}')
+  
+          # Send a PATCH request to update the description
+          curl -s -X PATCH -H "Content-Type: application/json" -H "Authorization: JWT $(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"$DOCKER_USERNAME\", \"password\": \"$DOCKER_ACCESS_TOKEN\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)" -d "$JSON_PAYLOAD" $API_URL

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -44,7 +44,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Update Docker Hub README
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           # Get the current README.md content

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Update Docker Hub README
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           # Get the current README.md content
           README_CONTENT=$(cat README.md)
@@ -56,5 +56,12 @@ jobs:
           # Create JSON payload
           JSON_PAYLOAD=$(jq -n --arg msg "$README_CONTENT" '{"full_description": $msg}')
 
-          # Send a PATCH request to update the description
-          curl -s -X PATCH -H "Content-Type: application/json" -H "Authorization: JWT $(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"$DOCKER_USERNAME\", \"password\": \"$DOCKER_ACCESS_TOKEN\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)" -d "$JSON_PAYLOAD" $API_URL
+          TOKEN=$(curl -s -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"username\": \"$DOCKER_USERNAME\", \"password\": \"$DOCKER_PASSWORD\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          curl -s -X PATCH \
+            -H "Content-Type: application/json" \
+            -H "Authorization: JWT $TOKEN" \
+            -d "$JSON_PAYLOAD" $API_URL


### PR DESCRIPTION
As part of the Docker Hub push, we want the README.md contents to be pushed to Docker Hub.  This approach can be augmented to have a separate README.md like README-DOCKERHUB.md if we want in the future.

## Pull request type
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation or Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes

## Description
Updates to the main-docker.yml to add a docker hub description update step.

## Changes
- M2 Milestone related change.

## Tests
- validating by enabling pushes on PRs to dev; will be removed once successful
- 
## Other information
Current Overview on Docker Hub:
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/ffc0170d-b36a-47ad-b71b-2aeb2364ffed">

New Overview screenshot to come.