### PR TITLE
Updating docker base image and useing docker entrypoint and new user

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -1,6 +1,9 @@
 # This workflow will build and push a docker image to dockerhub
 name: Main Docker
 
+env:
+  IMAGE_NAME: datafog/datafog-api:latest,datafog/datafog-api:1-latest
+
 on:
   workflow_run:
     workflows: ["Main and Dev CICD datafog-api app"]
@@ -8,6 +11,8 @@ on:
       - main
     types:
       - completed
+  pull_request:
+    branches: ["dev"]
 
 jobs:
   build-and-push-docker:
@@ -30,13 +35,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: datafog/datafog-api:latest,datafog/datafog-api:1-latest
+          provenance: mode=max
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -2,7 +2,8 @@
 name: Main Docker
 
 env:
-  IMAGE_NAME: datafog/datafog-api:latest,datafog/datafog-api:1-latest
+  IMAGE_NAME: datafog/datafog-api
+  MAJOR_VERSION: 1
 
 on:
   workflow_run:
@@ -48,7 +49,10 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ env.MAJOR_VERSION }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -12,8 +12,6 @@ on:
       - main
     types:
       - completed
-  pull_request:
-    branches: ["dev"]
 
 jobs:
   build-and-push-docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN python3.11 -m venv .venv && . .venv/bin/activate && \
     .venv/bin/pip install -r /home/datafoguser/app/requirements.txt
 
 WORKDIR /home/datafoguser/app
+USER datafoguser
 ENTRYPOINT ["sh", "docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -7,14 +7,18 @@ EXPOSE 8000
 RUN apt-get update && apt-get install -y \
     vim \
     git \
-    python3-pip \
     python3.11 \
+    python3-pip \
+    python3-venv \
     wget
 
-ADD app /root/app
+RUN useradd -ms /bin/bash datafoguser
 
-RUN python3.11 -m pip install -r /root/app/requirements.txt
+ADD app /home/datafoguser/app
 
+RUN python3.11 -m venv .venv && . .venv/bin/activate && \
+    pip install --upgrade setuptools==70.0.0 pip==23.2  && \
+    .venv/bin/pip install -r /home/datafoguser/app/requirements.txt
 
-WORKDIR /root/app
-ENTRYPOINT ["python3.11", "-m", "uvicorn", "--host=0.0.0.0","main:app"]
+WORKDIR /home/datafoguser/app
+ENTRYPOINT ["sh", "docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get install -y \
     vim \
     git \
     python3.11 \
-    python3-pip \
     python3-venv \
     wget
 
@@ -17,7 +16,7 @@ RUN useradd -ms /bin/bash datafoguser
 ADD app /home/datafoguser/app
 
 RUN python3.11 -m venv .venv && . .venv/bin/activate && \
-    pip install --upgrade setuptools==70.0.0 pip==23.2  && \
+    .venv/bin/pip install --upgrade pip && \
     .venv/bin/pip install -r /home/datafoguser/app/requirements.txt
 
 WORKDIR /home/datafoguser/app

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -1,0 +1,2 @@
+#/bin/sh
+. /.venv/bin/activate && uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Removing security violations found in our docker image by upgrading to Ubuntu 23.10, adding a user and upgrading specific packages.

## Pull request type
Please check the type of change your PR introduces:

- Build related changes

## Changes
- upgrade Ubuntu 22.04 -> Ubuntu 23.10
- add datafoguser
- add new docker-entrypoint.sh to start app instead of trying to update the entrypoint constantly
- upgraded specific packages with known CVEs

Issue Number (if applicable): https://hub.docker.com/layers/datafog/datafog-api/1-latest/images/sha256-d2210762052aa18ca1c6d814124c7b412fd5a3bf4dc38154f40863d7217228b7?context=repo&tab=vulnerabilities

## Tests
% docker scout cves datafog-api:latest

## Other information

- Ubuntu 24.04 is blocked by DataFog-python not supporting Python 3.12 currently